### PR TITLE
Fix user_data updated_at column not updating on no change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 
 # NPM package-lock
 package-lock.json
+pnpm-lock.yaml
+pnpm-workspace.yaml

--- a/fetcher.js
+++ b/fetcher.js
@@ -108,7 +108,7 @@ async function fullRankingsUpdate(mode, type, cursor_string) {
                     const insertUserDataStartTime = process.hrtime();
                     const user_data = elem;
                     const res = await conn.query(
-                        "INSERT INTO osu_score_user_data (user_id, mode, user_data) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE user_data=?",
+                        "INSERT INTO osu_score_user_data (user_id, mode, user_data) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE user_data=?, updated_at=NOW()",
                         [id, MODES[mode], user_data, user_data],
                     );
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express": "^4.18.0",
     "express-status-monitor": "^1.3.4",
     "ioredis": "^5.0.4",
-    "mariadb": "^3.2.0",
+    "mariadb": "^3.5.2",
     "morgan": "^1.10.0",
     "prom-client": "^15.1.2",
     "response-time": "^2.3.2"


### PR DESCRIPTION
`updated_at` should change every time user data is fetched, even if it has not changed since.\
MariaDB would treat such UPDATE attempt as a no-op, so the ON UPDATE from the column's definition wasn't enough.

Only tested for standard, but seems to work with up-to-date dumps and 1.5 iterations of the fetcher:
```
SELECT count(user_id) FROM osu_score_user_data\
WHERE updated_at > NOW() - INTERVAL 5 minute AND mode = 0;
+----------------+
| count(user_id) |
+----------------+
|          10000 |
+----------------+
```

I don't think this change is necessary for `osu_score_rank_highest` and `osu_score_rank_history` but idk