### PR TITLE
Banish axios

### DIFF
--- a/express.js
+++ b/express.js
@@ -223,7 +223,7 @@ async function main() {
         let users = req.params.users.split(",");
         let scores = req.query.score?.split(",") ?? [];
 
-        if (["username", "user_id"].includes(req.query.s) == -1 || req.query.s == undefined) {
+        if (!req.query.s || !["username", "user_id"].includes(req.query.s)) {
             req.query.s = "user_id";
         }
 
@@ -240,6 +240,7 @@ async function main() {
             if (req.query.s == "username") {
                 user_id = await redisClient.hget("username_to_user_id", user);
             } else {
+                // no validation to allow old `rank_highest` entries for users outside redis cache
                 user_id = user;
             }
 

--- a/express.js
+++ b/express.js
@@ -108,7 +108,7 @@ async function getPeakRank(user_id, mode) {
     observeDbQueryDuration(duration, "getPeakRank");
 
     let rank_highest = rows[0]?.rank
-        ? { rank: rows[0].rank, updated_at: rows[0].updated_at }
+        ? { rank: rows[0].rank, updated_at: rows[0].achieved_at }
         : null;
     return rank_highest;
 }
@@ -130,13 +130,13 @@ async function getRankHistory(user_id, mode) {
     const duration = endTime[0] + endTime[1] / 1e9;
     observeDbQueryDuration(duration, "getRankHistory");
 
-    if (!rows[0]?.rank_history || !rows[0]?.updated_at) {
+    if (!rows[0]?.rank_history || !rows[0]?.latest_rank_date) {
         return null;
     }
 
     let rank_history = [];
 
-    let current_date = new Date(rows[0].updated_at);
+    let current_date = new Date(rows[0].latest_rank_date);
     for (let i = rows[0].rank_history.length - 1; i >= 0; i--) {
         rank_history.push({
             rank: rows[0].rank_history[i],

--- a/fetcher.js
+++ b/fetcher.js
@@ -1,4 +1,3 @@
-const axios = require("axios");
 const Redis = require("ioredis");
 const redisClient = new Redis();
 const config = require("./config");
@@ -12,6 +11,8 @@ const pool = mariadb.createPool({
     connectionLimit: 5,
 });
 
+const API_URL = "https://osu.ppy.sh/api/v2";
+const AUTH_URL = "https://osu.ppy.sh/oauth/token";
 const MODES = {
     osu: 0,
     taiko: 1,
@@ -41,29 +42,40 @@ let done = true;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+function buildRankingApiUrl(mode, type, cursor_string) {
+    const url = new URL(`${API_URL}/rankings/${mode}/${type}`);
+    cursor_string && url.searchParams.set("cursor_string", cursor_string);
+    return url;
+}
+
 async function refreshToken() {
     return new Promise((resolve, reject) => {
-        axios({
-            url: "https://osu.ppy.sh/oauth/token",
-            method: "post",
+        fetch(AUTH_URL, {
+            method: "POST",
             headers: {
                 Accept: "application/json",
                 "Content-Type": "application/json",
             },
-            data: {
+            body: JSON.stringify({
                 grant_type: "client_credentials",
                 client_id: config.osu.id,
                 client_secret: config.osu.secret,
                 scope: "public",
-            },
+            }),
         })
+        .then((res) => {
+            if(!res.ok) {
+                throw new Error(`Token refresh failed: ${res.status} ${res.statusText}`);
+            }
+
+            res.json()
             .then((data) => {
-                refresh = Date.now() + data.data.expires_in * 1000;
-                resolve("Bearer " + data.data.access_token);
+                refresh = Date.now() + data.expires_in * 1000;
+                resolve("Bearer " + data.access_token);
             })
-            .catch((err) => {
-                reject(err);
-            });
+            .catch(reject);
+        })
+        .catch(reject);
     });
 }
 
@@ -73,25 +85,27 @@ async function fullRankingsUpdate(mode, type, cursor_string) {
         token = await refreshToken();
     }
 
-    let osuAPI = axios.create({
-        baseURL: "https://osu.ppy.sh/api/v2",
-        headers: { Authorization: token },
-        json: true,
-    });
-
     const osuAPIStartTime = process.hrtime();
-    osuAPI
-        .get("/rankings/" + mode + "/" + type, { params: { cursor_string: cursor_string } })
-        .then(async (res) => {
+    fetch(
+        buildRankingApiUrl(mode, type, cursor_string), {
+        headers: { Authorization: token }
+    })
+    .then((res) => {
+        if(!res.ok) {
+            throw new Error(`API request failed: ${res.status} ${res.statusText}`);
+        }
+
+        res.json()
+        .then(async (data) => {
             const osuAPIEndTime = process.hrtime(osuAPIStartTime);
             const osuAPIDuration = osuAPIEndTime[0] + osuAPIEndTime[1] / 1e9;
             observeOsuApiRequestDuration(osuAPIDuration, mode, res.status);
 
             let i = 0;
 
-            // console.log("Adding " + res.data.ranking.length + " Entries to the db");
+            // console.log("Adding " + data.ranking.length + " Entries to the db");
 
-            await res.data.ranking.forEach(async (elem) => {
+            await data.ranking.forEach(async (elem) => {
                 i++;
                 entries++;
 
@@ -108,7 +122,7 @@ async function fullRankingsUpdate(mode, type, cursor_string) {
                     const insertUserDataStartTime = process.hrtime();
                     const user_data = elem;
                     const res = await conn.query(
-                        "INSERT INTO osu_score_user_data (user_id, mode, user_data) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE user_data=?, updated_at=NOW()",
+                        "INSERT INTO osu_score_user_data (user_id, mode, user_data) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE user_data=?, updated_at=current_timestamp()",
                         [id, MODES[mode], user_data, user_data],
                     );
 
@@ -153,8 +167,8 @@ async function fullRankingsUpdate(mode, type, cursor_string) {
                 }
             });
 
-            if (res.data.cursor_string != null) {
-                cursor_string = res.data.cursor_string;
+            if (data.cursor_string != null) {
+                cursor_string = data.cursor_string;
                 await sleep(1000);
                 fullRankingsUpdate(mode, type, cursor_string);
                 retries[mode][type] = 0;
@@ -174,24 +188,32 @@ async function fullRankingsUpdate(mode, type, cursor_string) {
                 done = true;
             }
         })
-        .catch(async (err) => {
-            const osuAPIEndTime = process.hrtime(osuAPIStartTime);
-            const osuAPIDuration = osuAPIEndTime[0] + osuAPIEndTime[1] / 1e9;
-
-            observeOsuApiRequestDuration(osuAPIDuration, mode, err.response?.status || "Unknown");
-
-            if (retries[mode][type] < 4) {
-                console.log(err);
-                console.log("Retry: " + retries[mode][type]);
-                retries[mode][type]++;
-                await sleep(1000 * (retries[mode][type] * 10));
-                fullRankingsUpdate(mode, type, cursor_string);
-            } else {
-                console.log("Max retries reached, giving up.");
-                retries[mode][type] = 0;
-                done = true;
-            }
+        .catch((err) => {
+            handleRankingApiError(err, mode, type, cursor_string, osuAPIStartTime);
         });
+    })
+    .catch((err) => {
+        handleRankingApiError(err, mode, type, cursor_string, osuAPIStartTime);
+    });
+}
+
+async function handleRankingApiError(err, mode, type, cursor_string, osuAPIStartTime) {
+    const osuAPIEndTime = process.hrtime(osuAPIStartTime);
+    const osuAPIDuration = osuAPIEndTime[0] + osuAPIEndTime[1] / 1e9;
+
+    observeOsuApiRequestDuration(osuAPIDuration, mode, err.response?.status || "Unknown");
+
+    if (retries[mode][type] < 4) {
+        console.log(err);
+        console.log("Retry: " + retries[mode][type]);
+        retries[mode][type]++;
+        await sleep(1000 * (retries[mode][type] * 10));
+        fullRankingsUpdate(mode, type, cursor_string);
+    } else {
+        console.log("Max retries reached, giving up.");
+        retries[mode][type] = 0;
+        done = true;
+    }
 }
 
 let m = -1;

--- a/migr/2026-06-04_rename_updated_at_columns.sql
+++ b/migr/2026-06-04_rename_updated_at_columns.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `osu_score_rank_highest`
+RENAME COLUMN IF EXISTS `updated_at` TO `achieved_at`;
+
+ALTER TABLE `osu_score_rank_history`
+RENAME COLUMN IF EXISTS `updated_at` TO `latest_rank_date`;
+
+ANALYZE TABLE `osu_score_rank_highest`, `osu_score_rank_history`, `osu_score_user_data`;

--- a/package.json
+++ b/package.json
@@ -9,16 +9,14 @@
   "author": "respektive",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.27.2",
     "express": "^4.18.0",
     "express-status-monitor": "^1.3.4",
-    "ioredis": "^5.0.4",
+    "ioredis": "^5.11.0",
     "mariadb": "^3.5.2",
-    "morgan": "^1.10.0",
     "prom-client": "^15.1.2",
     "response-time": "^2.3.2"
   },
-  "directories": {
-    "test": "test"
+  "devDependencies": {
+    "morgan": "^1.11.0"
   }
 }

--- a/table.sql
+++ b/table.sql
@@ -1,8 +1,6 @@
--- MariaDB dump 10.19-11.3.2-MariaDB, for debian-linux-gnu (aarch64)
---
--- Host: localhost    Database: osu
+-- MariaDB dump 10.19-12.3.2-MariaDB, for Linux (x86_64)
 -- ------------------------------------------------------
--- Server version	11.3.2-MariaDB-1:11.3.2+maria~deb12
+-- Server version	12.3.2-MariaDB
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -13,7 +11,7 @@
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
 
 --
 -- Table structure for table `osu_score_rank_highest`
@@ -21,12 +19,12 @@
 
 DROP TABLE IF EXISTS `osu_score_rank_highest`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `osu_score_rank_highest` (
   `user_id` int(10) unsigned NOT NULL,
   `mode` tinyint(4) NOT NULL,
   `rank` int(11) DEFAULT 0,
-  `updated_at` timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `achieved_at` timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   PRIMARY KEY (`user_id`,`mode`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
  PARTITION BY RANGE (`mode`)
@@ -42,12 +40,12 @@ CREATE TABLE `osu_score_rank_highest` (
 
 DROP TABLE IF EXISTS `osu_score_rank_history`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `osu_score_rank_history` (
   `user_id` int(10) unsigned NOT NULL,
   `mode` tinyint(4) NOT NULL,
   `rank_history` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '[]' CHECK (json_valid(`rank_history`)),
-  `updated_at` timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `latest_rank_date` timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   PRIMARY KEY (`user_id`,`mode`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -58,7 +56,7 @@ CREATE TABLE `osu_score_rank_history` (
 
 DROP TABLE IF EXISTS `osu_score_user_data`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `osu_score_user_data` (
   `user_id` int(10) unsigned NOT NULL,
   `mode` tinyint(4) NOT NULL,
@@ -75,6 +73,6 @@ CREATE TABLE `osu_score_user_data` (
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
 
--- Dump completed on 2026-06-03  2:41:35
+-- Dump completed on 2026-06-04 16:26:39


### PR DESCRIPTION
Replaces ancient-ish axios with native nodejs fetch API. Kinda ugly, can refactor to async/await if needed.\
Also renames `updated_at` columns via an SQL script to make more sense.

Tested:
- Failure to obtain a token - still crashes the entire script
- Error while sending an osu! API request or parsing the response - still uses the retry up to 3 times logic
- prom seems to work
- API looks as cool as usual